### PR TITLE
Add current year as seed

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -16,6 +16,7 @@ import re
 import sys
 import networkx as nx
 import matplotlib.pyplot as plt
+import datetime
 
 
 logging.basicConfig(
@@ -26,6 +27,9 @@ logging.basicConfig(
 
 Logger = logging.getLogger(__name__)
 
+year = datetime.datetime.now().year
+Logger.debug("Setting seed to %s", year)
+random.seed(year)
 
 parser = argparse.ArgumentParser(description=__doc__)
 


### PR DESCRIPTION
I believe that randomly computing the assignment can cause issues (e.g. when the `pairs.json` file is lost).

Adding a seed allows us to assign the matching deterministically. Thus, I suggest to use the current year as a seed, as secret santa is only once a year.