### PR TITLE
Add easy way to see codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ run npm run build
 from caddy
 
 copy --from=builder ./dist /srv
-copy --from=draws ./pairs.json ./codes.json /srv
+copy --from=draws ./pairs.json ./codes.json /srv/
 
 expose 80
 cmd [ "caddy", "file-server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ run pip install -r requirements.txt
 copy ./scripts/draw.py ./default.conf ./
 
 run python draw.py --config default.conf --codes codes.json > pairs.json
-run echo codes.json
+run cat codes.json
 
 from node:16 as builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ run pip install -r requirements.txt
 
 copy ./scripts/draw.py ./default.conf ./
 
-run python draw.py --config default.conf > pairs.json
-
+run python draw.py --config default.conf --codes codes.json > pairs.json
+run echo codes.json
 
 from node:16 as builder
 
@@ -23,7 +23,7 @@ run npm run build
 from caddy
 
 copy --from=builder ./dist /srv
-copy --from=draws ./pairs.json /srv
+copy --from=draws ./pairs.json ./codes.json /srv
 
 expose 80
 cmd [ "caddy", "file-server" ]

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ docker build -t simple-secret-santa .
 docker run --rm -it -p80:80 simple-secret-santa
 ```
 
+To extract the codes you can do:
+
+```shell
+docker run --rm -it simple-secret-santa cat codes.json
+```
+
 ## Demo
 
 <p align="center">

--- a/scripts/draw.py
+++ b/scripts/draw.py
@@ -49,6 +49,13 @@ parser.add_argument(
     type=int,
     help=f'Random seed used to make the draw deterministic. Default: {datetime.datetime.now().year}'
 )
+parser.add_argument(
+    '--codes',
+    default=None,
+    type=str,
+    help=f'Specify the output file where the codes you can distribute to will be written. This is only for your convencience.'
+    # pairs.json contains the codes too
+)
 
 Sections = collections.namedtuple(
         'Sections',
@@ -350,15 +357,22 @@ def graph_to_b64dict(d2graph: nx.DiGraph) -> list:
     '''
 
     pairs = []
+    codes = []
 
     for f, t in d2graph.edges:
+        code = ''.join(str(random.choice(range(10))) for _ in range(6))
         pairs.append({
-            'code': ''.join(str(random.choice(range(10))) for _ in range(6)),
+            'code': code,
             'from': f,
             'to': base64.b64encode(t.encode()).decode(),
         })
 
-    return pairs
+        codes.append({
+            'person': f,
+            'code': code,
+        })
+
+    return pairs, codes
 
 
 if __name__ == "__main__":
@@ -394,5 +408,10 @@ if __name__ == "__main__":
         plt.show()
 
     Logger.info('Encoding and dumping result as JSON')
-    pairs = graph_to_b64dict(reduced_g)
+    pairs, codes = graph_to_b64dict(reduced_g)
+
+    if args.codes:
+        with open(args.codes, "w") as f:
+            f.write(json.dumps(codes))
+
     print(json.dumps(pairs))


### PR DESCRIPTION
I found it very cumbersome to see the codes, especially since I don't want to see the base64 encoding of the pairs. So I thought it might be a good idea to create an easy way to list the codes.

I changed the script so that it has an option --codes to list an output file for the generated codes, used it in the docker builds, and documented it in the README.md.

Hope you like it