### PR TITLE
feat: include personal code in URL params

### DIFF
--- a/site/src/components/Draw/Draw.tsx
+++ b/site/src/components/Draw/Draw.tsx
@@ -3,6 +3,7 @@ import {
   createRenderEffect,
   createSignal,
   Match,
+  onMount,
   Show,
   Switch,
 } from "solid-js";
@@ -27,6 +28,15 @@ export default function Draws(props: Props) {
   const pair = createMemo(
     () => props.draws?.find((draw) => draw.code === code()) ?? null,
   );
+
+  // Check for code in URL parameters on mount
+  onMount(() => {
+    const params = new URLSearchParams(window.location.search);
+    const urlCode = params.get("code");
+    if (urlCode && urlCode.length === 6) {
+      setCode(urlCode);
+    }
+  });
 
   createRenderEffect(() => {
     if (code()) {


### PR DESCRIPTION
Hi,

First thank you for this simple yet powerful project, it is exactly what I was looking for!

I performed some small modifications for my use-case that may be of interest to you. This one is for including the personal code in the URL directly.

This way, instead of sending a URL and a code separately, I can simply send something such as `https://example.com?code=123456`, and it will have the same behavior as if the user had typed in the code.

I tested it both locally with Docker and deployed on GitHub Pages, seems to work well.

Let me know if you'd like any modification on this, and thank you for your time 👌🏻 