### PR TITLE
feat: add configurable GitHub Pages support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,16 @@ on:
         description: Sets an extra message in the final "Make a present to" section (e.g., "The budget is 5€").
         required: false
         default: ''
+      deploy-to-pages:
+        type: boolean
+        description: Deploy the site to GitHub Pages
+        required: false
+        default: false
+      pages-use-custom-domain:
+        type: boolean
+        description: Use a custom domain for GitHub Pages (CNAME file)
+        required: false
+        default: false
 
 name: Build
 
@@ -113,6 +123,7 @@ jobs:
         working-directory: site
 
     env:
+      PUBLIC_BASE_URL: ${{ github.event.inputs.deploy-to-pages == 'true' && github.event.inputs.pages-use-custom-domain != 'true' && format('/{0}/', github.event.repository.name) || '/' }}
       PUBLIC_I18N_LANGUAGE: ${{ github.event.inputs.language }}
       PUBLIC_I18N_OVERRIDE_HTML_TITLE: ${{ github.event.inputs.override-html-title }}
       PUBLIC_I18N_OVERRIDE_CODE_PROMPT: ${{ github.event.inputs.override-code-prompt }}
@@ -142,3 +153,28 @@ jobs:
         with:
           name: dist
           path: site/dist/
+
+      - uses: actions/upload-pages-artifact@v3
+        if: ${{ github.event.inputs.deploy-to-pages == 'true' }}
+        with:
+          path: site/dist/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: ${{ github.event.inputs.deploy-to-pages == 'true' }}
+    needs: site
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -4,6 +4,7 @@ import solidJs from "@astrojs/solid-js";
 
 // https://astro.build/config
 export default defineConfig({
+  base: process.env.PUBLIC_BASE_URL || "/",
   integrations: [solidJs()],
   server: {
     allowedHosts: true,

--- a/site/src/components/Claus/3d/objects/Claus.ts
+++ b/site/src/components/Claus/3d/objects/Claus.ts
@@ -5,7 +5,7 @@ import {
 } from "three/examples/jsm/loaders/GLTFLoader.js";
 
 const gltf: GLTF = await new GLTFLoader()
-  .setPath("/models/")
+  .setPath(`${import.meta.env.BASE_URL}models/`)
   .loadAsync("claus.glb");
 
 export default class Claus {


### PR DESCRIPTION
Hello again,

I felt it made more sense to separate the two features I added for myself in two separate PRs, in case one interests you but not the other.

This one is about making it easy to deploy `dist` to GitHub Pages directly, while keeping the default behavior as before:

- GitHub Pages support is included in `build.yaml`, but is only executed if a workflow param is set to `true`. If not, this part of the workflow is simply ignored.
- Since GitHub Pages website get deployed to an address with a base URL by default, for example `username.github.io/secret-santa/`, I added automated support for base URL in the Astro configuration.
- The base URL is taken from an environment variable and falls back to `/` by default (keeping the default behavior as before)
- The `Claus` component also needed to be modified for this, as it uses a "hardcoded" URL. I added the base URL there too

I tested locally with Docker and in the Actions tab of GitHub, works fine for me. One possible improvement would be to make the base URL configurable instead of simply enabling/disabling it, to set a custom base URL, but I'm not sure it is necessary.

Let me know if you'd like any modification on this, and thank you for your time 👌🏻